### PR TITLE
docs: tighten Grimnir documentation entrypoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,15 @@
 # .env.example — copy to .env and fill in your values
 # Never commit .env to version control
 
-# PostgreSQL connection string — connect to your TimescaleDB instance
+# PostgreSQL connection string — connect to your TimescaleDB instance.
+# The example omits a password; set your real credential-bearing URL in .env.
 # Must use the asyncpg driver prefix for SQLAlchemy async + sync bootstrap URL conversion
-DATABASE_URL=postgresql+asyncpg://csi_user:changeme@db.example.com:5432/csi
+DATABASE_URL=postgresql+asyncpg://csi_user@db.example.com:5432/csi
 
 # Aggregator UDP port (must match AGGREGATOR_PORT in firmware/config.h)
 UDP_PORT=5005
 
-# Backend HTTP port
+# Host port published for Freki's dashboard and API
 BACKEND_PORT=8000
 
 # Logging level (debug, info, warning, error)
@@ -24,5 +25,5 @@ MODEL_UPLOAD_SHARED_SECRET=
 # X-Grimnir-ML-Control-Secret on daemon heartbeats and job claim/update calls.
 ML_CONTROL_SHARED_SECRET=
 
-# Geri: Prometheus metrics HTTP port (set to 0 to disable)
-METRICS_PORT=8001
+# Geri: Prometheus metrics HTTP port inside the Compose network (set to 0 to disable)
+GERI_METRICS_PORT=8001

--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -116,7 +116,9 @@ jobs:
 
       - name: Lint chart
         if: steps.version.outputs.release == 'true'
-        run: helm lint bifrost/helm/grimnir/
+        run: >-
+          helm lint bifrost/helm/grimnir/
+          --set database.url="postgresql+asyncpg://csi_user@db.example.com:5432/csi"
 
       - name: Log in to GHCR
         if: steps.version.outputs.release == 'true'
@@ -171,7 +173,7 @@ jobs:
             echo '```bash'
             echo "helm install grimnir oci://ghcr.io/dannysauer/charts/grimnir \\"
             echo "  --version ${CHART_VERSION} \\"
-            echo '  --set database.url="postgresql+asyncpg://user:pass@host:5432/csi"'
+            echo '  --set database.url="postgresql+asyncpg://csi_user@db.example.com:5432/csi"'
             echo '```'
             echo ""
             echo "### Upgrade"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,8 +240,7 @@ jobs:
             echo ""
             echo '```bash'
             echo "helm install grimnir oci://ghcr.io/dannysauer/charts/grimnir \\"
-            echo "  --version <chart-version> \\"
-            echo '  --set database.url="postgresql+asyncpg://user:pass@host:5432/csi"'
+            echo '  --set database.url="postgresql+asyncpg://csi_user@db.example.com:5432/csi"'
             echo '```'
           } > release-notes.md
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,58 +127,13 @@
     }
   ],
   "results": {
-    ".env.example": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": ".env.example",
-        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
-        "is_verified": false,
-        "line_number": 6
-      }
-    ],
-    ".github/workflows/chart-release.yml": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": ".github/workflows/chart-release.yml",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_verified": false,
-        "line_number": 150
-      }
-    ],
-    ".github/workflows/release.yml": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": ".github/workflows/release.yml",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_verified": false,
-        "line_number": 225
-      }
-    ],
-    "CLAUDE.md": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "CLAUDE.md",
-        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
-        "is_verified": false,
-        "line_number": 448
-      }
-    ],
-    "README.md": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "README.md",
-        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
-        "is_verified": false,
-        "line_number": 92
-      }
-    ],
     "bifrost/ansible/deploy.yaml": [
       {
         "type": "Secret Keyword",
         "filename": "bifrost/ansible/deploy.yaml",
         "hashed_secret": "eaba162c556d513d2960062d370ca01ad7ad5270",
         "is_verified": false,
-        "line_number": 123
+        "line_number": 149
       }
     ],
     "bifrost/helm/grimnir/values.yaml": [
@@ -187,7 +142,7 @@
         "filename": "bifrost/helm/grimnir/values.yaml",
         "hashed_secret": "01d2f16edf3fa20e9cd27c1c6b0eb187128e0c4c",
         "is_verified": false,
-        "line_number": 42
+        "line_number": 43
       }
     ],
     "docs/style-guides/google/go/best-practices.md": [
@@ -198,43 +153,7 @@
         "is_verified": false,
         "line_number": 3941
       }
-    ],
-    "freki/src/freki/main.py": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "freki/src/freki/main.py",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_verified": false,
-        "line_number": 10
-      }
-    ],
-    "geri/src/geri/main.py": [
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "geri/src/geri/main.py",
-        "hashed_secret": "9d4e1e23bd5b727046a9e3b4b7db57bd8d6ee684",
-        "is_verified": false,
-        "line_number": 11
-      }
-    ],
-    "mimir/001_schema.sql": [
-      {
-        "type": "Secret Keyword",
-        "filename": "mimir/001_schema.sql",
-        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
-        "is_verified": false,
-        "line_number": 10
-      }
-    ],
-    "mimir/src/csi_models/sql/001_schema.sql": [
-      {
-        "type": "Secret Keyword",
-        "filename": "mimir/src/csi_models/sql/001_schema.sql",
-        "hashed_secret": "fa9beb99e4029ad5a6615399e7bbae21356086b3",
-        "is_verified": false,
-        "line_number": 10
-      }
     ]
   },
-  "generated_at": "2026-04-19T18:59:20Z"
+  "generated_at": "2026-06-08T02:45:16Z"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,11 +31,10 @@ See `GRIMNIR.md` for the full naming reference. Summary:
 ## Hardware
 
 - **1× ESP32-S3** transmitter (Huginn) — broadcasts UDP beacons at 10 Hz
-- **2× ESP32-S3** receivers (Muninn) — capture CSI, stream to aggregator
+- **2+ ESP32-S3** receivers (Muninn) — capture CSI, stream to aggregator
 - Expandable to 6 total devices (1 tx + 5 rx) without schema changes
-- **humpy** — Ubuntu 20.04 NAS/server running PostgreSQL 12 + TimescaleDB 2.11.2
-- Kubernetes cluster available for container workloads
-- GPU machines (Tesla M4, P100) available for ML training
+- External PostgreSQL 12+ with TimescaleDB 2.11+
+- Docker Compose for standalone deployment, or Kubernetes for Helm deployment
 
 ## Repository Structure
 
@@ -53,12 +52,16 @@ grimnir/
 │   └── hooks/
 │       └── pre-commit-check.sh     # PreToolUse hook script
 ├── docs/
+│   ├── api-reference.md            # Freki and Volva HTTP/SSE surface
+│   ├── deployment.md               # Compose, Helm, Ansible, DB setup
 │   ├── firmware-build-and-flash.md # Linux + Windows firmware build guide
+│   ├── monorepo.md                 # Component map and command matrix
+│   ├── udp-wire-protocol.md        # Muninn-to-Geri UDP packet contract
 │   └── style-guides/
 │       └── google/                 # Google style guides (git subtree, gh-pages branch)
 │           ├── pyguide.md          # Python style guide
 │           ├── shellguide.md       # Shell style guide
-│           └── ...                 # cppguide.html, jsguide.html, etc.
+│           └── additional vendored Google style guide files
 ├── mimir/
 │   ├── pyproject.toml
 │   ├── 001_schema.sql              # SQL reference for the schema/bootstrap
@@ -114,7 +117,7 @@ grimnir/
 ├── hlidskjalf/
 │   └── index.html                  # Single-file mobile-first dashboard (vanilla JS)
 ├── firmware/
-│   ├── config.h                    # ← EDIT BEFORE FLASHING each board
+│   ├── config.h                    # Shared defaults; override with config.local.h
 │   ├── huginn/
 │   │   ├── platformio.ini          # PlatformIO build (framework = espidf)
 │   │   └── main/main.c             # Transmitter ESP-IDF v5.1+ C firmware
@@ -123,9 +126,11 @@ grimnir/
 │       └── main/main.c             # Receiver ESP-IDF v5.1+ C firmware
 └── bifrost/                        # Deployment: Compose + Helm + Ansible
     ├── compose.yaml
-    ├── helm/grimnir/               # Helm chart (both geri + freki)
+    ├── helm/grimnir/               # Helm chart (geri, freki, nornir, volva)
     │   ├── Chart.yaml
-    │   ├── values.yaml             # All options documented inline
+    │   ├── README.md               # Chart package entrypoint
+    │   ├── values.yaml             # Defaults with inline comments
+    │   ├── values.schema.json      # Helm values validation
     │   ├── files/
     │   │   └── grimnir-dashboard.json  # Grafana dashboard (Helm .Files.Get)
     │   └── templates/              # Kubernetes manifests
@@ -314,7 +319,7 @@ Helm's `{{ }}` syntax is not valid YAML.
 
 ## Database
 
-**Server:** humpy (Ubuntu 20.04), PostgreSQL 12, TimescaleDB 2.11.2
+**Server:** external PostgreSQL 12+ with TimescaleDB 2.11+
 **Database name:** `csi`
 **User:** `csi_user`
 
@@ -342,18 +347,19 @@ is bundled into the installed package for first-boot bootstrap.
 **Privilege requirement for fully automatic first boot:** the target database
 must either already have the `timescaledb` extension installed, or the
 configured role must be able to run `CREATE EXTENSION timescaledb`. On
-PostgreSQL 12 / TimescaleDB 2.11 that typically means a superuser role.
+PostgreSQL 12 / TimescaleDB 2.11 that typically means an elevated role.
 
-To bootstrap a fresh database manually:
+Recommended bootstrap:
 ```bash
 psql -U postgres -c "CREATE DATABASE csi;"
-psql -U postgres -c "CREATE USER csi_user WITH PASSWORD 'changeme' CREATEDB;"
-psql -U postgres -c "ALTER USER csi_user WITH SUPERUSER;"
+psql -U postgres -d csi -c "CREATE EXTENSION IF NOT EXISTS timescaledb;"
+createuser -U postgres --pwprompt csi_user
 psql -U postgres -c "GRANT ALL ON DATABASE csi TO csi_user;"
-psql -U postgres -d csi -f mimir/001_schema.sql
+psql -U postgres -d csi -c "GRANT CREATE ON SCHEMA public TO csi_user;"
 ```
-Or just start a service with `DATABASE_URL` set — the bundled SQL bootstrap will
-create the schema automatically if the role has the required privileges.
+Then start a service with `DATABASE_URL` set. The bundled SQL bootstrap creates
+the schema automatically. If a lab bootstrap temporarily grants superuser to the
+runtime role, revoke it after `migrations.done`.
 
 ## UDP Wire Protocol
 
@@ -426,8 +432,8 @@ Reader-facing deployment contract: `docs/deployment.md`.
 
 ### Standalone (Docker Compose)
 
-The compose file uses the external database on humpy — it does NOT spin up a
-Postgres container. Set `DATABASE_URL` in `.env` to point at humpy.
+The compose file uses an external database; it does NOT spin up a Postgres
+container. Set `DATABASE_URL` in `.env`.
 
 ```bash
 cp .env.example .env
@@ -439,14 +445,16 @@ docker compose -f bifrost/compose.yaml up -d
 
 ```bash
 ansible-playbook bifrost/ansible/deploy.yaml \
-  -e db_url="postgresql+asyncpg://csi_user:changeme@humpy.home.arpa:5432/csi" \
-  -e registry="your-registry.example.com" \
-  -e aggregator_lb_ip="192.168.1.50"
+  -e db_url="postgresql+asyncpg://csi_user@db.example.com:5432/csi" \
+  -e metallb_pool="default" \
+  -e metallb_lb_ip="192.0.2.50" \
+  -e freki_hostname="grimnir.home.example.com"
 ```
 
-The geri Service should be type LoadBalancer. Use MetalLB address pool annotations
-and external-dns `hostname` annotation to get an IP from the pool and create DNS
-automatically — no static IP configuration required:
+The Geri Service should be type LoadBalancer. Use MetalLB address pool
+annotations and external-dns `hostname` annotation to get an IP from the pool and
+create DNS automatically. Set `geri.service.loadBalancerIP` only when the target
+cluster still expects `spec.loadBalancerIP`:
 
 ```yaml
 geri:
@@ -496,9 +504,10 @@ Helm chart supports optional `ServiceMonitor` resources and a Grafana sidecar
 
 See `TODO.md` for the full checklist with GitHub issue numbers. Key items:
 
-- [ ] **Tests** (#4) — pytest + pytest-asyncio; `parser.py` is highest priority
+- [ ] **Supply chain security** (#3) — SBOMs, image signing, VEX, and attestations
 - [ ] **HTTPS / auth** (#5) — no authentication on freki; add nginx + basic auth. Narrow mitigations: `POST /api/models` can be gated with `MODEL_UPLOAD_SHARED_SECRET` (#29), and Nornir's daemon/job ML control writes can be gated with `ML_CONTROL_SHARED_SECRET` (#27).
 - [ ] **Phase calibration** (#7) — raw phase has hardware offsets; preprocess before ML
+- [ ] **Pet vs human labels** (#14) — split occupant tracking before relying on human-only counts
 
 ## ML Pipeline
 
@@ -536,5 +545,6 @@ extractor output changes, which Völva enforces on model load.
 label — `occupants` currently includes pets (#14). A predicted room is reported
 as `human_count=1` with all other known rooms at `0`.
 
-GPU machines (Tesla P100) are available if a future trainer needs them; the
-current `RandomForestClassifier` trains on CPU in seconds on typical datasets.
+The current `RandomForestClassifier` trains on CPU in seconds on typical home
+datasets. Add hardware-specific trainer notes only when the code uses that
+hardware path.

--- a/GRIMNIR.md
+++ b/GRIMNIR.md
@@ -22,7 +22,7 @@ project vocabulary, not a pending rename plan.
 
 - Python package names are lowercase: `geri`, `freki`, `nornir`, `volva`,
   and `csi-models`.
-- Docker images are published under `ghcr.io/dannysauer/grimnir/<component>`.
+- Docker images are published under `ghcr.io/dannysauer/grimnir/COMPONENT`.
 - The Helm chart name and expected release name are both `grimnir`.
 - Firmware receiver names should be stable and location-oriented, such as
   `grimnir-rx-office` or `grimnir-rx-upstairs`.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Start here, then follow the component docs for the task you are doing:
 | Read the Freki REST/SSE API and service health endpoints | [API reference](docs/api-reference.md) |
 | Read the Muninn-to-Geri UDP packet contract | [UDP wire protocol](docs/udp-wire-protocol.md) |
 | Run the stack with Compose, Helm, or Ansible | [Deployment guide](docs/deployment.md) |
+| Install or configure the Helm chart directly | [Helm chart README](bifrost/helm/grimnir/README.md) |
 | Understand the component names | [Naming reference](GRIMNIR.md) |
 | Track known follow-up work | [TODO checklist](TODO.md) |
 
@@ -68,8 +69,11 @@ Create a database or point Grimnir at an existing PostgreSQL database with the
 TimescaleDB extension available. The runtime URL must use the asyncpg driver:
 
 ```bash
-postgresql+asyncpg://csi_user:changeme@db.example.com:5432/csi
+postgresql+asyncpg://csi_user@db.example.com:5432/csi
 ```
+
+The example omits a password. Put the real credential-bearing URL in `.env` for
+Compose, or in a Kubernetes Secret for Helm.
 
 For a standalone Compose run:
 
@@ -82,8 +86,10 @@ docker compose -f bifrost/compose.yaml up -d
 For Helm:
 
 ```bash
+CHART_VERSION=0.1.1
 helm install grimnir oci://ghcr.io/dannysauer/charts/grimnir \
-  --set database.url="postgresql+asyncpg://csi_user:changeme@db.example.com:5432/csi"
+  --version "$CHART_VERSION" \
+  --set database.url="postgresql+asyncpg://csi_user@db.example.com:5432/csi"
 ```
 
 For firmware:

--- a/TODO.md
+++ b/TODO.md
@@ -36,8 +36,8 @@ as GitHub issues where noted.
 
 ## Testing
 
-- [ ] **pytest + pytest-asyncio** test suite for `geri` and `freki`.
-      Priority: `geri/src/geri/parser.py` (pure function, easy to unit test).
+- [x] **pytest + pytest-asyncio** test suite for `geri` and `freki`.
+      Parser and Freki router coverage now run in CI.
       _(#4)_
 
 ---
@@ -97,10 +97,9 @@ as GitHub issues where noted.
 
 ## Helm / Kubernetes
 
-- [ ] **Helm: empty `loadBalancerIP`** — when `geri.service.loadBalancerIP` is
-      not set, the template must omit the field entirely rather than emit an
+- [x] **Helm: empty `loadBalancerIP`** — when `geri.service.loadBalancerIP` is
+      not set, the template omits the field entirely rather than emitting an
       empty string, which some cloud providers reject.
-      _(already guarded by `if` in the current template)_
 
 ---
 

--- a/bifrost/ansible/deploy.yaml
+++ b/bifrost/ansible/deploy.yaml
@@ -8,13 +8,13 @@
 #
 # Usage (minimal):
 #   ansible-playbook bifrost/ansible/deploy.yaml \
-#     -e db_url="postgresql+asyncpg://csi_user:changeme@db.example.com:5432/csi"
+#     -e db_url="postgresql+asyncpg://csi_user@db.example.com:5432/csi"
 #
 # Usage (with MetalLB + external-dns, typical home-lab setup):
 #   ansible-playbook bifrost/ansible/deploy.yaml \
-#     -e db_url="postgresql+asyncpg://csi_user:changeme@db.example.com:5432/csi" \
+#     -e db_url="postgresql+asyncpg://csi_user@db.example.com:5432/csi" \
 #     -e metallb_pool=default \
-#     -e metallb_lb_ip=192.168.1.50 \
+#     -e metallb_lb_ip=192.0.2.50 \
 #     -e freki_hostname=grimnir.home.example.com \
 #     -e freki_ingress_class=nginx
 
@@ -32,7 +32,7 @@
 
     # MetalLB — leave blank if not using MetalLB
     metallb_pool: ""       # e.g. "default" or "lan-pool"
-    metallb_lb_ip: ""      # e.g. "192.168.1.50" (must be in the pool range)
+    metallb_lb_ip: ""      # e.g. "192.0.2.50" (must be in the pool range)
 
     # external-dns + ingress — leave blank to skip Ingress creation
     freki_hostname: ""          # e.g. "grimnir.home.example.com"
@@ -46,7 +46,7 @@
     - name: Validate required vars
       ansible.builtin.assert:
         that: db_url != ""
-        fail_msg: "db_url is required. Pass with -e db_url=postgresql+asyncpg://..."
+        fail_msg: "db_url is required. Pass -e db_url=postgresql+asyncpg://USER@HOST:5432/DB_NAME"
 
     - name: Ensure namespace exists
       kubernetes.core.k8s:
@@ -77,6 +77,26 @@
         source: build
         push: true
 
+    - name: Build and push nornir image
+      community.docker.docker_image:
+        build:
+          path: "{{ playbook_dir }}/../.."
+          dockerfile: nornir/Dockerfile
+        name: "ghcr.io/dannysauer/grimnir/nornir"
+        tag: "{{ image_tag }}"
+        source: build
+        push: true
+
+    - name: Build and push volva image
+      community.docker.docker_image:
+        build:
+          path: "{{ playbook_dir }}/../.."
+          dockerfile: volva/Dockerfile
+        name: "ghcr.io/dannysauer/grimnir/volva"
+        tag: "{{ image_tag }}"
+        source: build
+        push: true
+
     - name: Build Helm values
       ansible.builtin.set_fact:
         helm_values:
@@ -86,6 +106,12 @@
               tag: "{{ image_tag }}"
             freki:
               repository: ghcr.io/dannysauer/grimnir/freki
+              tag: "{{ image_tag }}"
+            nornir:
+              repository: ghcr.io/dannysauer/grimnir/nornir
+              tag: "{{ image_tag }}"
+            volva:
+              repository: ghcr.io/dannysauer/grimnir/volva
               tag: "{{ image_tag }}"
           database:
             url: "{{ db_url }}"

--- a/bifrost/ansible/install.yaml
+++ b/bifrost/ansible/install.yaml
@@ -3,7 +3,7 @@
 # Provision the external PostgreSQL/TimescaleDB database, then deploy Grimnir.
 #
 # This playbook assumes:
-# - PostgreSQL runs on the Ansible host named `humpy`
+# - PostgreSQL runs on the Ansible host named by `grimnir_db_admin_host`
 # - PostgreSQL local peer auth allows `become_user: postgres`
 # - k3s access is available from localhost via ~/.kube/config
 # - the Grimnir chart is published to GHCR as an OCI chart
@@ -12,7 +12,7 @@
 #   ansible-playbook bifrost/ansible/install.yaml -e @/path/to/grimnir.yml
 
 - name: Provision Grimnir database
-  hosts: "{{ grimnir_db_admin_host | default('humpy') }}"
+  hosts: "{{ grimnir_db_admin_host | default('grimnir-db-admin') }}"
   gather_facts: false
   become: true
   become_user: postgres
@@ -122,14 +122,14 @@
     grimnir_release_name: grimnir
     grimnir_chart_ref: oci://ghcr.io/dannysauer/charts/grimnir
     grimnir_chart_version: ""
-    grimnir_db_host: humpy.home.dannysauer.com
+    grimnir_db_host: db.home.example.com
     grimnir_db_port: 5432
     grimnir_db_name: grimnir
     grimnir_db_user: grimnir
     grimnir_db_password: ""
-    grimnir_freki_hostname: grimnir.home.dannysauer.com
+    grimnir_freki_hostname: grimnir.home.example.com
     grimnir_freki_ingress_class: traefik
-    grimnir_geri_hostname: grimnir-udp.home.dannysauer.com
+    grimnir_geri_hostname: grimnir-udp.home.example.com
     grimnir_metallb_pool: ""
     grimnir_geri_loadbalancer_ip: ""
 

--- a/bifrost/compose.yaml
+++ b/bifrost/compose.yaml
@@ -6,7 +6,7 @@
 #
 # Exposes:
 #   UDP 5005  — ESP32 CSI data ingress (Geri)
-#   TCP 8000  — Web dashboard + API (Freki + Hlidskjalf)
+#   TCP ${BACKEND_PORT:-8000} — Web dashboard + API (Freki + Hlidskjalf)
 #
 # Note: PostgreSQL is NOT included — provide DATABASE_URL in .env pointing at
 #       your existing TimescaleDB instance.
@@ -26,6 +26,7 @@ services:
       BATCH_SIZE:       "50"
       BATCH_TIMEOUT_MS: "500"
       LOG_LEVEL:        "info"
+      METRICS_PORT:     ${GERI_METRICS_PORT:-8001}
     ports:
       - "5005:5005/udp"
     networks:
@@ -50,7 +51,7 @@ services:
       MODEL_UPLOAD_SHARED_SECRET: ${MODEL_UPLOAD_SHARED_SECRET:-}
       ML_CONTROL_SHARED_SECRET: ${ML_CONTROL_SHARED_SECRET:-}
     ports:
-      - "8000:8000"
+      - "${BACKEND_PORT:-8000}:8000"
     networks:
       - grimnir-internal
     healthcheck:

--- a/bifrost/helm/grimnir/README.md
+++ b/bifrost/helm/grimnir/README.md
@@ -7,6 +7,33 @@ This chart installs the Grimnir home Wi-Fi CSI localization stack on Kubernetes:
 - Nornir training daemon.
 - Volva live inference service.
 
+The following diagram shows the chart-managed workloads and the external systems
+they depend on:
+
+```mermaid
+flowchart LR
+    muninn["Muninn receiver firmware"]
+    lb["Geri Service UDP 5005"]
+    geri["Geri Deployment"]
+    freki["Freki Deployment and Service"]
+    nornir["Nornir Deployment"]
+    volva["Volva Deployment and Service"]
+    db["External PostgreSQL + TimescaleDB"]
+    user["Dashboard/API user"]
+
+    muninn -->|"CSI UDP packets"| lb
+    lb --> geri
+    geri -->|"CSI rows"| db
+    freki --> db
+    nornir -->|"training jobs and model upload"| freki
+    volva -->|"CSI stream and prediction writes"| freki
+    user --> freki
+```
+
+In text form, the chart exposes Geri for receiver UDP traffic, runs Freki for the
+dashboard/API, runs Nornir and Volva as internal HTTP clients of Freki, and uses
+an external TimescaleDB-backed PostgreSQL database for persistent state.
+
 The chart is published to the GHCR OCI registry:
 
 ```bash

--- a/bifrost/helm/grimnir/README.md
+++ b/bifrost/helm/grimnir/README.md
@@ -1,0 +1,215 @@
+# Grimnir Helm Chart
+
+This chart installs the Grimnir home Wi-Fi CSI localization stack on Kubernetes:
+
+- Geri UDP packet ingress and TimescaleDB writer.
+- Freki dashboard, REST API, SSE streams, and metrics.
+- Nornir training daemon.
+- Volva live inference service.
+
+The chart is published to the GHCR OCI registry:
+
+```bash
+helm show chart oci://ghcr.io/dannysauer/charts/grimnir
+```
+
+## Prerequisites
+
+- Kubernetes cluster with a load-balancer path that ESP32 Muninn receivers can
+  reach on UDP port 5005.
+- PostgreSQL with TimescaleDB. The chart does not install a database.
+- Container image pull access to `ghcr.io/dannysauer/grimnir/*`.
+- Optional Prometheus Operator CRDs when `prometheus.serviceMonitor.enabled` is
+  set.
+- Optional Vertical Pod Autoscaler CRDs when `vpa.enabled` is set.
+- Optional Grafana sidecar support when `grafana.dashboard.enabled` is set.
+
+Install TimescaleDB before starting Grimnir when possible. The runtime database
+role should not remain a superuser in a long-running deployment.
+
+## Install
+
+Install from the published OCI chart:
+
+```bash
+CHART_VERSION=0.1.1
+helm install grimnir oci://ghcr.io/dannysauer/charts/grimnir \
+  --version "$CHART_VERSION" \
+  --set database.url="postgresql+asyncpg://csi_user@db.example.com:5432/csi"
+```
+
+The example URL omits a password. Use a credential-bearing URL in your local
+shell, uncommitted values file, or Kubernetes Secret.
+
+For shared clusters, prefer a pre-created Secret instead of putting credentials
+in Helm values:
+
+```bash
+CHART_VERSION=0.1.1
+kubectl create secret generic grimnir-db \
+  --from-literal=DATABASE_URL="postgresql+asyncpg://csi_user@db.example.com:5432/csi"
+
+helm install grimnir oci://ghcr.io/dannysauer/charts/grimnir \
+  --version "$CHART_VERSION" \
+  --set database.existingSecret=grimnir-db
+```
+
+## Upgrade
+
+```bash
+CHART_VERSION=0.1.1
+helm upgrade grimnir oci://ghcr.io/dannysauer/charts/grimnir \
+  --version "$CHART_VERSION" \
+  --reuse-values
+```
+
+Check rollout and health after upgrading:
+
+```bash
+kubectl rollout status deployment/grimnir-freki
+kubectl rollout status deployment/grimnir-geri
+kubectl rollout status deployment/grimnir-nornir
+kubectl rollout status deployment/grimnir-volva
+kubectl port-forward svc/grimnir-freki 8000:8000
+curl -fsS http://127.0.0.1:8000/health
+```
+
+## Uninstall
+
+```bash
+helm uninstall grimnir
+```
+
+The uninstall removes Kubernetes resources created by the chart. It does not
+delete the external database, database credentials, load-balancer DNS records, or
+firmware configuration.
+
+## Values
+
+The chart validates values with `values.schema.json`. Run local validation from
+the repository root:
+
+```bash
+helm lint bifrost/helm/grimnir \
+  --set database.url="postgresql+asyncpg://csi_user@db.example.com:5432/csi"
+
+helm template grimnir bifrost/helm/grimnir \
+  --set database.url="postgresql+asyncpg://csi_user@db.example.com:5432/csi"
+```
+
+Common values:
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `image.geri.repository` | `ghcr.io/dannysauer/grimnir/geri` | Geri image repository. |
+| `image.geri.tag` | `""` | Geri image tag; defaults to `Chart.appVersion`. |
+| `image.freki.repository` | `ghcr.io/dannysauer/grimnir/freki` | Freki image repository. |
+| `image.freki.tag` | `""` | Freki image tag; defaults to `Chart.appVersion`. |
+| `image.nornir.repository` | `ghcr.io/dannysauer/grimnir/nornir` | Nornir image repository. |
+| `image.nornir.tag` | `""` | Nornir image tag; defaults to `Chart.appVersion`. |
+| `image.volva.repository` | `ghcr.io/dannysauer/grimnir/volva` | Volva image repository. |
+| `image.volva.tag` | `""` | Volva image tag; defaults to `Chart.appVersion`. |
+| `imagePullSecrets` | `[]` | Image pull secrets added to all pods. |
+| `revisionHistoryLimit` | `3` | Old ReplicaSets retained per deployment. |
+| `database.url` | `""` | PostgreSQL URL using the `postgresql+asyncpg://` driver. Required unless `database.existingSecret` is set. |
+| `database.existingSecret` | `""` | Existing Secret containing the database URL. |
+| `database.secretKey` | `DATABASE_URL` | Key in the database Secret. |
+| `modelUploadAuth.sharedSecret` | `""` | Optional shared secret for `POST /api/models`; creates a Secret when set. |
+| `modelUploadAuth.existingSecret` | `""` | Existing Secret for model upload auth. |
+| `modelUploadAuth.secretKey` | `MODEL_UPLOAD_SHARED_SECRET` | Key for model upload auth. |
+| `mlControlAuth.sharedSecret` | `""` | Optional shared secret for Nornir daemon and job-control writes. |
+| `mlControlAuth.existingSecret` | `""` | Existing Secret for ML control auth. |
+| `mlControlAuth.secretKey` | `ML_CONTROL_SHARED_SECRET` | Key for ML control auth. |
+| `geri.replicaCount` | `1` | Geri replicas. UDP load-balancing should keep each sender on one pod. |
+| `geri.service.type` | `LoadBalancer` | Service type for Muninn UDP ingress. |
+| `geri.service.port` | `5005` | UDP port exposed by the service. |
+| `geri.service.loadBalancerIP` | `""` | Optional fixed LoadBalancer IP; omitted when empty. |
+| `geri.service.externalTrafficPolicy` | `Local` | Preserves receiver source IPs for heartbeat records. |
+| `geri.service.annotations` | `{}` | Service annotations, commonly MetalLB and external-dns. |
+| `geri.env` | See `values.yaml` | Extra Geri environment variables such as `BATCH_SIZE`, `BATCH_TIMEOUT_MS`, `LOG_LEVEL`, and `METRICS_PORT`. |
+| `freki.replicaCount` | `1` | Freki replicas. Current prediction state is stored in Postgres. |
+| `freki.service.type` | `ClusterIP` | Freki service type. |
+| `freki.service.port` | `8000` | Freki HTTP port. |
+| `freki.ingress.enabled` | `false` | Create an Ingress for dashboard and API access. |
+| `freki.ingress.className` | `""` | Optional ingress class. |
+| `freki.ingress.hosts` | `grimnir.example.com` | Ingress hosts and paths. |
+| `freki.ingress.tls` | `[]` | Optional TLS entries. |
+| `freki.livenessProbe` | See `values.yaml` | Freki liveness probe timing. |
+| `freki.readinessProbe` | See `values.yaml` | Freki readiness probe timing. |
+| `freki.env` | See `values.yaml` | Extra Freki environment variables. |
+| `nornir.replicaCount` | `1` | Nornir replicas. Job claims are race-safe. |
+| `nornir.service.port` | `8001` | Nornir metrics service port. |
+| `nornir.env` | See `values.yaml` | Nornir polling, heartbeat, metrics, and logging variables. |
+| `volva.replicaCount` | `1` | Volva replicas. Keep at one writer for current predictions. |
+| `volva.service.port` | `8002` | Volva health and metrics service port. |
+| `volva.livenessProbe` | See `values.yaml` | Volva liveness probe timing. |
+| `volva.readinessProbe` | See `values.yaml` | Volva readiness probe timing. |
+| `volva.env` | See `values.yaml` | Volva model refresh, windowing, and logging variables. |
+| `vpa.enabled` | `false` | Create VPA resources for all workloads. |
+| `vpa.updateMode` | `Off` | VPA update mode. Start with `Off` for recommendations only. |
+| `prometheus.serviceMonitor.enabled` | `false` | Create ServiceMonitor resources. |
+| `prometheus.serviceMonitor.namespace` | `""` | ServiceMonitor namespace; defaults to release namespace. |
+| `prometheus.serviceMonitor.labels` | `{}` | Extra labels for Prometheus Operator selection. |
+| `grafana.dashboard.enabled` | `false` | Create a dashboard ConfigMap for a Grafana sidecar. |
+| `grafana.dashboard.folder` | `Grimnir` | Grafana dashboard folder annotation. |
+
+## Geri Load Balancer
+
+Muninn firmware sends UDP packets to `AGGREGATOR_HOST` on port 5005. Point that
+hostname at the Geri load balancer address.
+
+Example MetalLB and external-dns annotations:
+
+```yaml
+geri:
+  service:
+    annotations:
+      metallb.universe.tf/address-pool: default
+      external-dns.alpha.kubernetes.io/hostname: csi-aggregator.home.example.com
+```
+
+Use `geri.service.loadBalancerIP` only when your cluster still relies on
+`spec.loadBalancerIP`. Leave it empty to omit the field.
+
+## Security Notes
+
+- Freki does not provide broad dashboard or API authentication yet. Do not expose
+  it beyond a trusted network without an ingress, gateway, or reverse proxy that
+  adds HTTPS and authentication.
+- Use `existingSecret` values for database URLs and shared secrets on shared
+  clusters.
+- `MODEL_UPLOAD_SHARED_SECRET` protects model upload writes when configured.
+- `ML_CONTROL_SHARED_SECRET` protects Nornir daemon and job-control writes when
+  configured.
+- The workloads do not call the Kubernetes API. The chart does not create RBAC
+  resources or dedicated service accounts.
+- Pods run as non-root UID 1000, disallow privilege escalation, and use
+  read-only root filesystems.
+
+## Observability
+
+Geri and Nornir expose metrics on dedicated metrics ports. Freki and Volva
+expose metrics on their HTTP service ports. Enable ServiceMonitors when a
+Prometheus Operator installation should scrape the services:
+
+```yaml
+prometheus:
+  serviceMonitor:
+    enabled: true
+```
+
+Enable the dashboard ConfigMap only when Grafana has a sidecar watching the
+configured label:
+
+```yaml
+grafana:
+  dashboard:
+    enabled: true
+```
+
+## More Documentation
+
+- [Deployment guide](../../../docs/deployment.md)
+- [API reference](../../../docs/api-reference.md)
+- [UDP wire protocol](../../../docs/udp-wire-protocol.md)
+- [Firmware build and flash guide](../../../docs/firmware-build-and-flash.md)

--- a/bifrost/helm/grimnir/templates/freki-deployment.yaml
+++ b/bifrost/helm/grimnir/templates/freki-deployment.yaml
@@ -15,7 +15,6 @@ spec:
     metadata:
       labels:
         {{- include "grimnir.selectorLabels" (merge (dict "component" "freki") .) | nindent 8 }}
-        app.kubernetes.io/component: freki
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/bifrost/helm/grimnir/templates/geri-deployment.yaml
+++ b/bifrost/helm/grimnir/templates/geri-deployment.yaml
@@ -15,7 +15,6 @@ spec:
     metadata:
       labels:
         {{- include "grimnir.selectorLabels" (merge (dict "component" "geri") .) | nindent 8 }}
-        app.kubernetes.io/component: geri
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/bifrost/helm/grimnir/templates/geri-service.yaml
+++ b/bifrost/helm/grimnir/templates/geri-service.yaml
@@ -11,6 +11,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.geri.service.type }}
+  {{- with .Values.geri.service.loadBalancerIP }}
+  loadBalancerIP: {{ . | quote }}
+  {{- end }}
   {{- with .Values.geri.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ . }}
   {{- end }}

--- a/bifrost/helm/grimnir/templates/nornir-deployment.yaml
+++ b/bifrost/helm/grimnir/templates/nornir-deployment.yaml
@@ -15,7 +15,6 @@ spec:
     metadata:
       labels:
         {{- include "grimnir.selectorLabels" (merge (dict "component" "nornir") .) | nindent 8 }}
-        app.kubernetes.io/component: nornir
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/bifrost/helm/grimnir/templates/volva-deployment.yaml
+++ b/bifrost/helm/grimnir/templates/volva-deployment.yaml
@@ -17,7 +17,6 @@ spec:
     metadata:
       labels:
         {{- include "grimnir.selectorLabels" (merge (dict "component" "volva") .) | nindent 8 }}
-        app.kubernetes.io/component: volva
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/bifrost/helm/grimnir/values.schema.json
+++ b/bifrost/helm/grimnir/values.schema.json
@@ -1,0 +1,456 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Grimnir Helm values",
+  "type": "object",
+  "additionalProperties": true,
+  "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "geri": {
+          "$ref": "#/definitions/image"
+        },
+        "freki": {
+          "$ref": "#/definitions/image"
+        },
+        "nornir": {
+          "$ref": "#/definitions/image"
+        },
+        "volva": {
+          "$ref": "#/definitions/image"
+        }
+      }
+    },
+    "imagePullSecrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "revisionHistoryLimit": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "database": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "url": {
+          "type": "string",
+          "anyOf": [
+            {
+              "enum": [
+                ""
+              ]
+            },
+            {
+              "pattern": "^postgresql\\+asyncpg://"
+            }
+          ]
+        },
+        "existingSecret": {
+          "type": "string"
+        },
+        "secretKey": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "modelUploadAuth": {
+      "$ref": "#/definitions/secretSetting"
+    },
+    "mlControlAuth": {
+      "$ref": "#/definitions/secretSetting"
+    },
+    "geri": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicaCount": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "resources": {
+          "$ref": "#/definitions/kubernetesMap"
+        },
+        "service": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "ClusterIP",
+                "NodePort",
+                "LoadBalancer"
+              ]
+            },
+            "port": {
+              "$ref": "#/definitions/port"
+            },
+            "loadBalancerIP": {
+              "type": "string"
+            },
+            "externalTrafficPolicy": {
+              "type": "string",
+              "enum": [
+                "",
+                "Cluster",
+                "Local"
+              ]
+            },
+            "annotations": {
+              "$ref": "#/definitions/stringMap"
+            }
+          }
+        },
+        "env": {
+          "$ref": "#/definitions/envMap"
+        }
+      }
+    },
+    "freki": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicaCount": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "resources": {
+          "$ref": "#/definitions/kubernetesMap"
+        },
+        "service": {
+          "$ref": "#/definitions/httpService"
+        },
+        "ingress": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "className": {
+              "type": "string"
+            },
+            "annotations": {
+              "$ref": "#/definitions/stringMap"
+            },
+            "hosts": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "host",
+                  "paths"
+                ],
+                "properties": {
+                  "host": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "paths": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": [
+                        "path",
+                        "pathType"
+                      ],
+                      "properties": {
+                        "path": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "pathType": {
+                          "type": "string",
+                          "enum": [
+                            "Exact",
+                            "Prefix",
+                            "ImplementationSpecific"
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "tls": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "env": {
+          "$ref": "#/definitions/envMap"
+        }
+      }
+    },
+    "nornir": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicaCount": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "resources": {
+          "$ref": "#/definitions/kubernetesMap"
+        },
+        "service": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "port": {
+              "$ref": "#/definitions/port"
+            },
+            "annotations": {
+              "$ref": "#/definitions/stringMap"
+            }
+          }
+        },
+        "env": {
+          "$ref": "#/definitions/envMap"
+        }
+      }
+    },
+    "volva": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicaCount": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 1
+        },
+        "resources": {
+          "$ref": "#/definitions/kubernetesMap"
+        },
+        "service": {
+          "$ref": "#/definitions/httpService"
+        },
+        "livenessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "readinessProbe": {
+          "$ref": "#/definitions/probe"
+        },
+        "env": {
+          "$ref": "#/definitions/envMap"
+        }
+      }
+    },
+    "vpa": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "updateMode": {
+          "type": "string",
+          "enum": [
+            "Off",
+            "Initial",
+            "Recreate",
+            "Auto"
+          ]
+        }
+      }
+    },
+    "prometheus": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "serviceMonitor": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "namespace": {
+              "type": "string"
+            },
+            "interval": {
+              "type": "string",
+              "minLength": 1
+            },
+            "scrapeTimeout": {
+              "type": "string",
+              "minLength": 1
+            },
+            "labels": {
+              "$ref": "#/definitions/stringMap"
+            }
+          }
+        }
+      }
+    },
+    "grafana": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "dashboard": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "folder": {
+              "type": "string"
+            },
+            "sidecarLabel": {
+              "type": "string",
+              "minLength": 1
+            },
+            "sidecarLabelValue": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tag": {
+          "type": "string"
+        },
+        "pullPolicy": {
+          "type": "string",
+          "enum": [
+            "Always",
+            "IfNotPresent",
+            "Never"
+          ]
+        }
+      }
+    },
+    "secretSetting": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "sharedSecret": {
+          "type": "string"
+        },
+        "existingSecret": {
+          "type": "string"
+        },
+        "secretKey": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "httpService": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "ClusterIP",
+            "NodePort",
+            "LoadBalancer"
+          ]
+        },
+        "port": {
+          "$ref": "#/definitions/port"
+        },
+        "annotations": {
+          "$ref": "#/definitions/stringMap"
+        }
+      }
+    },
+    "probe": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "initialDelaySeconds": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "periodSeconds": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "failureThreshold": {
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "port": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535
+    },
+    "stringMap": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "envMap": {
+      "type": "object",
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          },
+          {
+            "type": "integer"
+          },
+          {
+            "type": "boolean"
+          }
+        ]
+      }
+    },
+    "kubernetesMap": {
+      "type": "object",
+      "additionalProperties": true
+    }
+  }
+}

--- a/bifrost/helm/grimnir/values.yaml
+++ b/bifrost/helm/grimnir/values.yaml
@@ -30,11 +30,12 @@ revisionHistoryLimit: 3
 # -- Database connection (required)
 database:
   # Connection URL — must use the asyncpg driver prefix:
-  #   postgresql+asyncpg://user:password@host:port/dbname
+  #   postgresql+asyncpg://csi_user@db.example.com:5432/csi
   # For fully automatic first boot on a fresh database, this role must also
   # be able to create the TimescaleDB extension (`CREATE EXTENSION timescaledb`).
-  # On PostgreSQL 12 / TimescaleDB 2.11, that typically means a superuser role,
-  # unless the extension is preinstalled in the target database.
+  # On PostgreSQL 12 / TimescaleDB 2.11, that typically means an elevated role
+  # unless the extension is preinstalled in the target database. Prefer
+  # preinstalling TimescaleDB and using a least-privilege runtime role.
   url: ""
   # Optional: reference an existing Secret instead of creating one.
   # The Secret must contain the key specified by database.secretKey.
@@ -85,6 +86,10 @@ geri:
   service:
     type: LoadBalancer
     port: 5005
+    # Optional fixed LoadBalancer IP. Leave empty to omit spec.loadBalancerIP.
+    # For MetalLB, prefer the loadBalancerIPs annotation when your installation
+    # supports it.
+    loadBalancerIP: ""
     # Preserve the real receiver source IP so heartbeats show the device's LAN
     # address instead of a cluster-internal SNAT address.
     externalTrafficPolicy: Local

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,9 +1,10 @@
 # API Reference
 
 Freki is the public HTTP API for Grimnir. It also serves Hlidskjalf, the
-single-file dashboard, when the frontend directory is present in the container.
+single-file dashboard, when `FRONTEND_DIR` points at the dashboard directory in
+the container.
 
-At runtime, FastAPI also exposes generated OpenAPI and browser docs:
+At runtime, FastAPI exposes generated OpenAPI and browser docs:
 
 | Path | Purpose |
 |------|---------|
@@ -13,6 +14,19 @@ At runtime, FastAPI also exposes generated OpenAPI and browser docs:
 
 These generated pages are useful for exact request and response schemas. This
 document records the stable product surface and integration behavior.
+
+## Dashboard and Generated Documentation
+
+When `FRONTEND_DIR` exists, Freki mounts it at `/` with FastAPI `StaticFiles` and
+HTML index fallback enabled.
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| GET | `/` | None | Hlidskjalf dashboard shell from `hlidskjalf/index.html`. |
+| GET | `/label-preview.html` | None | Static label-preview helper page when present in the frontend directory. |
+| GET | `/openapi.json` | None | Generated Freki OpenAPI schema. |
+| GET | `/docs` | None | Generated Swagger UI. |
+| GET | `/redoc` | None | Generated ReDoc UI. |
 
 ## Service Endpoints
 
@@ -64,7 +78,7 @@ training job claim, heartbeat, complete, and fail calls.
 | GET | `/api/training-daemons` | None | Lists registered training daemons. |
 | POST | `/api/training-daemons/heartbeat` | JSON `name`, `host`, optional `ip_address`, optional `capabilities` | Upserts a daemon row and updates `last_seen`. Requires ML control secret when configured. |
 | GET | `/api/training-jobs` | Optional `status`, optional `limit`, default 50, max 500 | Lists training jobs. |
-| POST | `/api/training-jobs` | JSON `{"spec": {...}}` | Enqueues a job. Validates time order and room names. |
+| POST | `/api/training-jobs` | JSON object with a `spec` object | Enqueues a job. Validates time order and room names. |
 | POST | `/api/training-jobs/{job_id}/claim` | JSON `{"daemon_id": integer}` | Claims a queued job with a race-free conditional update. Requires ML control secret when configured. |
 | POST | `/api/training-jobs/{job_id}/heartbeat` | JSON `daemon_id`, `claim_token` | Updates heartbeat for the owning daemon and claim token. |
 | POST | `/api/training-jobs/{job_id}/complete` | JSON `daemon_id`, `claim_token` | Marks the owned running job complete and clears the claim token. |
@@ -116,12 +130,31 @@ Prediction envelope shape:
 ## Volva Service Endpoints
 
 Volva has no public prediction API. It dials Freki, consumes `/api/csi-stream`,
-and writes `/api/predictions/current`.
+and writes `/api/predictions/current`. Because Volva is also a FastAPI service,
+it exposes generated framework docs at `/openapi.json`, `/docs`, and `/redoc`;
+those generated routes describe the service-local health endpoint, not the
+Grimnir prediction product API.
 
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/health` | Returns service status, active model id, and model age. |
 | GET | `/metrics` | Prometheus metrics for active model state and HTTP instrumentation. |
+
+## Runtime Configuration
+
+These variables are part of the HTTP-facing behavior and are useful when
+debugging API or stream behavior:
+
+| Service | Variable | Default | Behavior |
+|---------|----------|---------|----------|
+| Freki | `FRONTEND_DIR` | `/app/frontend` | Directory mounted at `/` when it exists. |
+| Freki | `ORPHAN_CHECK_INTERVAL_S` | `60` | Poll interval for the training-job orphan reaper. |
+| Freki | `ORPHAN_TIMEOUT_S` | `300` | Running-job heartbeat age before the reaper marks it failed. |
+| Freki | `CSI_STREAM_INTERVAL_MS` | `200` | Poll interval for `/api/csi-stream`; values below 50 ms are clamped to 50 ms. |
+| Freki | `CSI_STREAM_MAX_BATCH` | `200` | Maximum CSI rows emitted per stream poll before older backlog is skipped. |
+| Geri | `ACK_INTERVAL_S` | `5` | Minimum seconds between UDP ACKs sent to the same Muninn sender address. |
+| Volva | `WINDOW_SIZE` | `50` | CSI rows per receiver window used for live inference. |
+| Volva | `MODEL_REFRESH_S` | `30` | Active-model refresh interval. |
 
 ## Source of Truth
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,6 +8,43 @@ Grimnir ships deployment assets under `bifrost/`:
 
 PostgreSQL with TimescaleDB is external in all shipped deployment modes.
 
+## Deployment Topology
+
+The shipped Compose and Helm assets deploy the four runtime services and expect
+the database and ESP32 devices to exist outside the deployment bundle:
+
+```mermaid
+flowchart LR
+    subgraph devices["ESP32 devices"]
+        huginn["Huginn transmitter"]
+        muninn["Muninn receivers"]
+    end
+
+    subgraph runtime["Compose or Helm deployment"]
+        geri["Geri UDP service"]
+        freki["Freki API and dashboard"]
+        nornir["Nornir training daemon"]
+        volva["Volva inference service"]
+    end
+
+    db["External PostgreSQL + TimescaleDB"]
+    browser["Browser / dashboard user"]
+    consumer["Automation consumer"]
+
+    huginn -->|"beacon frames"| muninn
+    muninn -->|"UDP 5005"| geri
+    geri -->|"migrations and CSI writes"| db
+    freki -->|"migrations, API reads, labels, models"| db
+    nornir -->|"training job claims and model upload"| freki
+    volva -->|"CSI stream and prediction writes"| freki
+    browser --> freki
+    consumer --> freki
+```
+
+In text form, receivers send UDP packets to Geri, Geri and Freki share the
+external TimescaleDB database, Nornir and Volva call Freki over HTTP, and users
+or automation consumers read dashboard/API state from Freki.
+
 ## Required Database
 
 Set `DATABASE_URL` to a PostgreSQL URL that uses the asyncpg SQLAlchemy driver:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -13,8 +13,11 @@ PostgreSQL with TimescaleDB is external in all shipped deployment modes.
 Set `DATABASE_URL` to a PostgreSQL URL that uses the asyncpg SQLAlchemy driver:
 
 ```text
-postgresql+asyncpg://csi_user:changeme@db.example.com:5432/csi
+postgresql+asyncpg://csi_user@db.example.com:5432/csi
 ```
+
+The examples in this repository omit passwords. Use the same URL shape with your
+real credentials in `.env`, an uncommitted values file, or a Kubernetes Secret.
 
 On startup, Geri and Freki call `run_migrations(DATABASE_URL)` from the Mimir
 package. That code converts the URL to `postgresql+psycopg2://` for synchronous
@@ -24,21 +27,36 @@ numbered SQL migrations.
 The target database must either already have the `timescaledb` extension
 installed, or the configured database role must be able to run
 `CREATE EXTENSION timescaledb`. On PostgreSQL 12 and TimescaleDB 2.11, fully
-automatic first boot commonly requires a superuser role unless the extension is
+automatic first boot commonly requires an elevated role unless the extension is
 preinstalled by an administrator.
 
-Manual bootstrap reference:
+Recommended bootstrap, with the extension installed by a database administrator
+before the runtime role is used by Grimnir:
 
 ```bash
 psql -U postgres -c "CREATE DATABASE csi;"
-psql -U postgres -c "CREATE USER csi_user WITH PASSWORD 'changeme' CREATEDB;"
-psql -U postgres -c "ALTER USER csi_user WITH SUPERUSER;"
+psql -U postgres -d csi -c "CREATE EXTENSION IF NOT EXISTS timescaledb;"
+createuser -U postgres --pwprompt csi_user
 psql -U postgres -c "GRANT ALL ON DATABASE csi TO csi_user;"
-psql -U postgres -d csi -f mimir/001_schema.sql
+psql -U postgres -d csi -c "GRANT CREATE ON SCHEMA public TO csi_user;"
 ```
 
-For long-running deployments, prefer preinstalling TimescaleDB and using the
-least-privileged database role that still supports the chosen bootstrap model.
+After this, start Freki or Geri with `DATABASE_URL`; the bundled Mimir migrations
+create and update Grimnir tables.
+
+For a short-lived lab bootstrap, you can grant the runtime role the elevated
+permissions required to create TimescaleDB objects, start one service once so
+Mimir applies migrations, then revoke the elevation:
+
+```bash
+psql -U postgres -c "ALTER USER csi_user WITH SUPERUSER;"
+# Start Freki or Geri once and wait for "migrations.done" in the service logs.
+psql -U postgres -c "ALTER USER csi_user WITH NOSUPERUSER;"
+```
+
+Do not leave the Grimnir runtime role as a superuser in a long-running
+deployment. If migrations fail, stop the services and inspect
+`schema_migrations` before granting broader privileges again.
 
 ## Docker Compose
 
@@ -89,18 +107,25 @@ oci://ghcr.io/dannysauer/charts/grimnir
 Minimal install:
 
 ```bash
+CHART_VERSION=0.1.1
 helm install grimnir oci://ghcr.io/dannysauer/charts/grimnir \
-  --set database.url="postgresql+asyncpg://csi_user:changeme@db.example.com:5432/csi"
+  --version "$CHART_VERSION" \
+  --set database.url="postgresql+asyncpg://csi_user@db.example.com:5432/csi"
 ```
+
+The chart also has a GitHub-rendered package entrypoint at
+[`bifrost/helm/grimnir/README.md`](../bifrost/helm/grimnir/README.md). Use that
+page for the full values reference, secret options, upgrade commands, and
+package metadata.
 
 For local chart validation from the repository:
 
 ```bash
 helm lint bifrost/helm/grimnir \
-  --set database.url="postgresql+asyncpg://csi_user:changeme@db.example.com:5432/csi"
+  --set database.url="postgresql+asyncpg://csi_user@db.example.com:5432/csi"
 
 helm template grimnir bifrost/helm/grimnir \
-  --set database.url="postgresql+asyncpg://csi_user:changeme@db.example.com:5432/csi"
+  --set database.url="postgresql+asyncpg://csi_user@db.example.com:5432/csi"
 ```
 
 The chart deploys these workloads:
@@ -158,14 +183,20 @@ Example:
 
 ```bash
 ansible-playbook bifrost/ansible/deploy.yaml \
-  -e db_url="postgresql+asyncpg://csi_user:changeme@db.example.com:5432/csi" \
-  -e aggregator_lb_ip="192.0.2.50" \
+  -e db_url="postgresql+asyncpg://csi_user@db.example.com:5432/csi" \
+  -e metallb_pool="default" \
+  -e metallb_lb_ip="192.0.2.50" \
   -e freki_hostname="grimnir.home.example.com"
 ```
 
 Use the Ansible path when you want a repeatable home-cluster deployment with
 MetalLB or external-dns inputs. Use direct Helm commands when iterating on chart
 changes.
+
+`bifrost/ansible/deploy.yaml` builds and pushes all four service images with the
+same `image_tag` value, then deploys the local chart. Use
+`bifrost/ansible/install.yaml` when you want the database provisioning path and a
+published OCI chart instead.
 
 ## Security Notes
 
@@ -190,7 +221,8 @@ Helm:
 
 ```bash
 helm history grimnir
-helm rollback grimnir <REVISION>
+REVISION=1
+helm rollback grimnir "$REVISION"
 kubectl rollout status deployment/grimnir-freki
 ```
 

--- a/docs/firmware-build-and-flash.md
+++ b/docs/firmware-build-and-flash.md
@@ -247,7 +247,7 @@ for these milestones:
 3. Muninn enables CSI capture.
 4. Geri receives packets and sends `grimnir-ack`.
 5. Muninn logs `Aggregator ACKs flowing`.
-6. Freki shows the receiver in the dashboard at `http://<freki-host>:8000`.
+6. Freki shows the receiver in the dashboard at `http://FREKI_HOST:8000`.
 
 Example monitor output:
 
@@ -278,7 +278,7 @@ Publish records like:
 
 ```dns
 _syslog._udp.home.example.com.         300 IN SRV 0 0 514 logs.home.example.com.
-logs.home.example.com.                 300 IN A   192.168.0.10
+logs.home.example.com.                 300 IN A   192.0.2.10
 ```
 
 With that in place, Muninn will query `_syslog._udp.home.example.com`, resolve

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -5,6 +5,40 @@ database migrations, a static dashboard, container definitions, and deployment
 assets. Work from the repository root unless a command explicitly says to
 change directories.
 
+## Runtime Flow
+
+The following diagram shows how the main components exchange CSI samples,
+training jobs, model artifacts, and current predictions:
+
+```mermaid
+flowchart LR
+    huginn["Huginn transmitter firmware"]
+    muninn["Muninn receiver firmware"]
+    geri["Geri UDP aggregator"]
+    db["PostgreSQL + TimescaleDB"]
+    freki["Freki API and dashboard server"]
+    dashboard["Hlidskjalf dashboard"]
+    nornir["Nornir training daemon"]
+    volva["Volva inference service"]
+    consumers["Consumers such as Home Assistant"]
+
+    huginn -->|"802.11 beacon frames"| muninn
+    muninn -->|"CSI UDP packets"| geri
+    geri -->|"CSI rows and receiver heartbeats"| db
+    db --> freki
+    freki --> dashboard
+    freki -->|"training jobs and labeled CSI"| nornir
+    nornir -->|"model artifact and job status"| freki
+    freki -->|"live CSI stream and active model"| volva
+    volva -->|"current prediction"| freki
+    freki --> consumers
+```
+
+In text form, Huginn creates radio frames, Muninn converts received CSI into UDP
+packets, Geri writes samples to TimescaleDB, Freki exposes the dashboard/API and
+coordinates model training, Nornir trains models, and Volva publishes live room
+predictions back through Freki.
+
 ## Component Map
 
 | Component | Path | Runtime role | Build or test entry point |

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -50,9 +50,10 @@ not the individual service directory.
 | Run all configured pre-commit hooks | Repository root | `pre-commit run --all-files` | Ruff, formatting, shell, GitHub Actions, YAML/JSON, and hygiene checks pass. |
 | Run Geri tests | Repository root | `pytest geri/tests` | Parser and aggregator tests pass. |
 | Run Freki tests | Repository root | `pytest freki/tests` | API router and auth tests pass. |
-| Validate Compose configuration | Repository root | `DATABASE_URL='postgresql+asyncpg://csi_user:changeme@db.example.com:5432/csi' docker compose -f bifrost/compose.yaml config` | Compose renders the full four-service stack. |
-| Lint Helm chart | Repository root | `helm lint bifrost/helm/grimnir --set database.url='postgresql+asyncpg://csi_user:changeme@db.example.com:5432/csi'` | Chart lint passes. |
-| Render Helm chart | Repository root | `helm template grimnir bifrost/helm/grimnir --set database.url='postgresql+asyncpg://csi_user:changeme@db.example.com:5432/csi'` | Kubernetes manifests render. |
+| Validate Compose configuration | Repository root | `DATABASE_URL='postgresql+asyncpg://csi_user@db.example.com:5432/csi' docker compose -f bifrost/compose.yaml config` | Compose renders the full four-service stack. |
+| Lint Helm chart | Repository root | `helm lint bifrost/helm/grimnir --set database.url='postgresql+asyncpg://csi_user@db.example.com:5432/csi'` | Chart lint passes. |
+| Render Helm chart | Repository root | `helm template grimnir bifrost/helm/grimnir --set database.url='postgresql+asyncpg://csi_user@db.example.com:5432/csi'` | Kubernetes manifests render. |
+| Validate Helm values schema | Repository root | `helm lint bifrost/helm/grimnir --set database.url='postgresql+asyncpg://csi_user@db.example.com:5432/csi'` | `values.schema.json` accepts the supplied values and rejects invalid shapes. |
 | Build Huginn firmware | `firmware/huginn/` | `idf.py set-target esp32s3 && idf.py build` | ESP-IDF produces firmware build output. |
 | Build Muninn firmware | `firmware/muninn/` | `idf.py set-target esp32s3 && idf.py build` | ESP-IDF produces firmware build output. |
 | Build firmware with PlatformIO | `firmware/huginn/` or `firmware/muninn/` | `pio run` | PlatformIO builds using `framework = espidf`. |
@@ -77,6 +78,6 @@ When changing a component, update the docs that describe its public behavior:
 |-------------|---------------|
 | Freki route, request body, response body, auth, or SSE behavior | `docs/api-reference.md`, `CLAUDE.md`, and tests. |
 | Muninn packet layout or parser behavior | `docs/udp-wire-protocol.md`, `docs/firmware-build-and-flash.md`, `geri/src/geri/parser.py`, and parser tests. |
-| Compose, Helm, Ansible, environment variables, ports, or image names | `docs/deployment.md`, `README.md`, `.env.example`, and `bifrost/helm/grimnir/values.yaml`. |
+| Compose, Helm, Ansible, environment variables, ports, or image names | `docs/deployment.md`, `README.md`, `.env.example`, `bifrost/helm/grimnir/README.md`, `bifrost/helm/grimnir/values.yaml`, and `bifrost/helm/grimnir/values.schema.json`. |
 | Firmware setup or flash workflow | `docs/firmware-build-and-flash.md`, `firmware/config.h`, and `firmware/config.local.h.example`. |
 | Component names, paths, or package boundaries | `README.md`, `GRIMNIR.md`, `docs/monorepo.md`, and `CLAUDE.md`. |

--- a/freki/src/freki/main.py
+++ b/freki/src/freki/main.py
@@ -8,7 +8,7 @@ Startup sequence:
   4. Serve FastAPI via uvicorn
 
 Environment variables:
-  DATABASE_URL               postgresql+asyncpg://user:pass@host:5432/csi
+  DATABASE_URL               postgresql+asyncpg://user@host:5432/csi
   HOST                       bind address (default 0.0.0.0)
   PORT                       bind port (default 8000)
   LOG_LEVEL                  debug | info | warning | error (default info)

--- a/freki/src/freki/ml_auth.py
+++ b/freki/src/freki/ml_auth.py
@@ -9,7 +9,7 @@ from typing import Annotated
 from fastapi import Header, HTTPException
 
 ML_CONTROL_SHARED_SECRET = os.environ.get("ML_CONTROL_SHARED_SECRET", "")
-ML_CONTROL_SECRET_HEADER = "X-Grimnir-ML-Control-Secret"
+ML_CONTROL_SECRET_HEADER = "X-Grimnir-ML-Control-Secret"  # pragma: allowlist secret
 
 
 def require_ml_control_secret(

--- a/freki/src/freki/routers/models.py
+++ b/freki/src/freki/routers/models.py
@@ -30,7 +30,7 @@ from ..db import SessionDep
 router = APIRouter()
 
 MODEL_UPLOAD_SHARED_SECRET = os.environ.get("MODEL_UPLOAD_SHARED_SECRET", "")
-MODEL_UPLOAD_SECRET_HEADER = "X-Grimnir-Model-Upload-Secret"
+MODEL_UPLOAD_SECRET_HEADER = "X-Grimnir-Model-Upload-Secret"  # pragma: allowlist secret
 
 
 # ── Pydantic schemas ──────────────────────────────────────────────────────────

--- a/geri/src/geri/main.py
+++ b/geri/src/geri/main.py
@@ -8,7 +8,7 @@ Startup sequence:
   4. Batch-write CSI packets to TimescaleDB
 
 Environment variables:
-  DATABASE_URL      postgresql+asyncpg://user:pass@host:5432/csi
+  DATABASE_URL      postgresql+asyncpg://user@host:5432/csi
   UDP_HOST          bind address (default 0.0.0.0)
   UDP_PORT          bind port (default 5005)
   BATCH_SIZE        rows to buffer before flushing (default 50)
@@ -95,7 +95,8 @@ class CSIUDPProtocol(asyncio.DatagramProtocol):
             return
 
         now = asyncio.get_running_loop().time()
-        if now - self._last_ack_sent.get(addr, 0.0) < ACK_INTERVAL_S:
+        last_ack = self._last_ack_sent.get(addr)
+        if last_ack is not None and now - last_ack < ACK_INTERVAL_S:
             return
 
         self._transport.sendto(ACK_PAYLOAD, addr)

--- a/mimir/001_schema.sql
+++ b/mimir/001_schema.sql
@@ -7,7 +7,8 @@
 --
 -- Then run:
 --   psql -U postgres -c "CREATE DATABASE csi;"
---   psql -U postgres -c "CREATE USER csi_user WITH PASSWORD 'changeme'; GRANT ALL ON DATABASE csi TO csi_user;"
+--   createuser -U postgres --pwprompt csi_user
+--   psql -U postgres -c "GRANT ALL ON DATABASE csi TO csi_user;"
 --   psql -U postgres -d csi -f mimir/001_schema.sql
 -- =============================================================================
 

--- a/mimir/src/csi_models/sql/001_schema.sql
+++ b/mimir/src/csi_models/sql/001_schema.sql
@@ -7,7 +7,8 @@
 --
 -- Then run:
 --   psql -U postgres -c "CREATE DATABASE csi;"
---   psql -U postgres -c "CREATE USER csi_user WITH PASSWORD 'changeme'; GRANT ALL ON DATABASE csi TO csi_user;"
+--   createuser -U postgres --pwprompt csi_user
+--   psql -U postgres -c "GRANT ALL ON DATABASE csi TO csi_user;"
 --   psql -U postgres -d csi -f mimir/001_schema.sql
 -- =============================================================================
 

--- a/nornir/src/nornir/freki_client.py
+++ b/nornir/src/nornir/freki_client.py
@@ -15,8 +15,8 @@ from typing import Any
 
 import httpx
 
-ML_CONTROL_SECRET_HEADER = "X-Grimnir-ML-Control-Secret"
-MODEL_UPLOAD_SECRET_HEADER = "X-Grimnir-Model-Upload-Secret"
+ML_CONTROL_SECRET_HEADER = "X-Grimnir-ML-Control-Secret"  # pragma: allowlist secret
+MODEL_UPLOAD_SECRET_HEADER = "X-Grimnir-Model-Upload-Secret"  # pragma: allowlist secret
 
 
 class FrekiError(RuntimeError):


### PR DESCRIPTION
## Summary
- Confirmed previous docs PR #52 is merged, then kept the GitHub README as the primary entrypoint and added a Helm chart package entrypoint.
- Added a chart README and values schema, documented chart install/upgrade/security/observability values, and fixed the documented Geri loadBalancerIP behavior in the template.
- Aligned deployment, API, Compose, Ansible, release-note, firmware, SQL/comment, TODO, and agent docs with the current repo behavior and removed secret-like placeholder examples.
- Fixed Geri first-ACK throttling so fresh CI runners and newly started processes send the initial receiver ACK before applying the interval.
- Added explicit `detect-secrets` allowlist pragmas for shared-secret header-name constants that are not credential values.

## Validation
- `git diff --check`
- `python3 -m json.tool bifrost/helm/grimnir/values.schema.json`
- Ruby YAML parse for workflows, Compose, Ansible, values, and Chart.yaml
- Markdown relative-link checker over root docs, docs/*.md, and chart README
- Stale placeholder/private-host scan over project docs, examples, workflows, and touched source comments
- `helm lint bifrost/helm/grimnir --set database.url=postgresql+asyncpg://csi_user@db.example.com:5432/csi`
- `helm template grimnir bifrost/helm/grimnir --set database.url=postgresql+asyncpg://csi_user@db.example.com:5432/csi`
- Helm template check with `geri.service.loadBalancerIP=192.0.2.50`
- `DATABASE_URL=postgresql+asyncpg://csi_user@db.example.com:5432/csi BACKEND_PORT=18000 GERI_METRICS_PORT=18001 docker compose -f bifrost/compose.yaml config`
- `pre-commit run --from-ref main --to-ref HEAD`
- `pre-commit run --all-files`
- `/tmp/grimnir-docs-pytest-venv/bin/python -m pytest geri/tests freki/tests`

## Residual findings
- `uv run --frozen pytest ...` is not usable because the repo has no `uv.lock`; tests were run from an isolated `/tmp` virtualenv instead.
- Helm lint still reports the informational `Chart.yaml: icon is recommended`; no chart icon asset exists in this docs pass.