### PR TITLE
fix(freki): propagate room renames to training_samples labels

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -54,7 +54,7 @@ SSE endpoints use `text/event-stream`, disable proxy buffering with
 |--------|------|---------------|-------------|
 | GET | `/api/rooms` | None | Lists rooms ordered by floor and name. |
 | POST | `/api/rooms` | JSON `{"name": string, "floor": integer}` | Creates a room. Returns `409` when the room already exists. |
-| PATCH | `/api/rooms/{room_name}` | JSON with optional `name` and `floor` | Updates room metadata. Name changes cascade to labels and update `csi_samples.label`. |
+| PATCH | `/api/rooms/{room_name}` | JSON with optional `name` and `floor` | Updates room metadata. A name change cascades to labels and rewrites the stored label on `csi_samples` and `training_samples`, so historical and training data follow the room. |
 | DELETE | `/api/rooms/{room_name}` | None | Deletes a room. Returns `409` when labels still reference it. |
 | GET | `/api/labels` | `minutes` optional, default 120 | Lists labels whose end time is within the requested window. |
 | POST | `/api/labels` | JSON `time_start`, `time_end`, `room`, `occupants`, optional `notes` | Creates a label and schedules best-effort backfill into CSI samples and training samples. |

--- a/freki/src/freki/routers/rooms.py
+++ b/freki/src/freki/routers/rooms.py
@@ -5,7 +5,8 @@ GET    /api/rooms             list all rooms ordered by floor, name
 POST   /api/rooms             create a room
 PATCH  /api/rooms/{name}      update name and/or floor
                               (name change cascades to labels via FK; also
-                               updates csi_samples.label which has no FK)
+                               rewrites csi_samples.label and
+                               training_samples.label, which have no FK)
 DELETE /api/rooms/{name}      delete a room (409 if labels reference it)
 """
 
@@ -13,15 +14,19 @@ from __future__ import annotations
 
 from datetime import datetime
 
+import structlog
 from csi_models import CsiSample, Room
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, field_validator
-from sqlalchemy import select, update
-from sqlalchemy.exc import IntegrityError
+from sqlalchemy import select, text, update
+from sqlalchemy.exc import DBAPIError, IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from ..db import SessionDep
+from ..training_samples_access import is_training_samples_permission_error
 
 router = APIRouter()
+log = structlog.get_logger(__name__)
 
 
 # ── Pydantic schemas ──────────────────────────────────────────────────────────
@@ -60,6 +65,34 @@ class RoomUpdate(BaseModel):
             if not v:
                 raise ValueError("name must not be empty")
         return v
+
+
+async def _rename_training_samples_label(
+    session: AsyncSession, old_name: str, new_name: str
+) -> None:
+    """Propagate a room rename to the denormalized training_samples.label.
+
+    Runs inside the caller's transaction under a savepoint, so a real
+    failure aborts the whole rename instead of leaving the tables split
+    between two names. Installs where training_samples is owned by a
+    different role (#34/#37) skip the sync with a warning so the rename
+    itself still succeeds.
+    """
+    try:
+        async with session.begin_nested():
+            await session.execute(
+                text("UPDATE training_samples SET label = :new_name WHERE label = :old_name"),
+                {"new_name": new_name, "old_name": old_name},
+            )
+    except DBAPIError as exc:
+        if not is_training_samples_permission_error(exc):
+            raise
+        log.warning(
+            "training_samples.rename_skipped",
+            reason="permission_denied",
+            old_name=old_name,
+            new_name=new_name,
+        )
 
 
 # ── Endpoints ─────────────────────────────────────────────────────────────────
@@ -106,11 +139,14 @@ async def update_room(room_name: str, body: RoomUpdate, session: SessionDep):
         raise HTTPException(status_code=409, detail=f"Room '{body.name}' already exists") from None
 
     # labels.room is updated automatically by the FK ON UPDATE CASCADE.
-    # csi_samples.label has no FK, so update it explicitly.
+    # csi_samples.label and training_samples.label have no FK, so update
+    # them explicitly — training_samples is what Nornir trains from, so a
+    # rename that skips it silently orphans that room's training data.
     if new_name != old_name:
         await session.execute(
             update(CsiSample).where(CsiSample.label == old_name).values(label=new_name)
         )
+        await _rename_training_samples_label(session, old_name, new_name)
 
     await session.commit()
 

--- a/freki/tests/conftest.py
+++ b/freki/tests/conftest.py
@@ -66,6 +66,14 @@ class FakeExecuteResult:
         return FakeMappingSequence(self._mappings_values)
 
 
+class _FakeNestedTransaction:
+    async def __aenter__(self) -> _FakeNestedTransaction:
+        return self
+
+    async def __aexit__(self, *_exc: object) -> None:
+        return None
+
+
 class FakeSession:
     def __init__(
         self,
@@ -85,6 +93,7 @@ class FakeSession:
         self.rollbacks = 0
         self.refreshes = 0
         self.flushes = 0
+        self.nested_begins = 0
 
     async def execute(self, statement: object, *args: object, **kwargs: object) -> object:
         self.execute_calls.append((statement, args, kwargs))
@@ -120,6 +129,10 @@ class FakeSession:
         self.flushes += 1
         if self.flush_exception is not None:
             raise self.flush_exception
+
+    def begin_nested(self) -> _FakeNestedTransaction:
+        self.nested_begins += 1
+        return _FakeNestedTransaction()
 
 
 class _FakeSessionContext:

--- a/freki/tests/test_rooms.py
+++ b/freki/tests/test_rooms.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from conftest import FakeExecuteResult, FakeSession
+from freki.routers import rooms
+from sqlalchemy.exc import ProgrammingError
+
+
+def _room(name: str, floor: int = 0) -> SimpleNamespace:
+    return SimpleNamespace(name=name, floor=floor, created_at=datetime(2026, 6, 1, tzinfo=UTC))
+
+
+@pytest.mark.asyncio
+async def test_update_room_rename_rewrites_training_samples_label() -> None:
+    session = FakeSession(
+        execute_results=[
+            FakeExecuteResult(scalar_value=_room("kitchen")),  # lookup by old name
+            FakeExecuteResult(),  # UPDATE csi_samples
+            FakeExecuteResult(),  # UPDATE training_samples
+            FakeExecuteResult(scalar_value=_room("pantry")),  # re-query by new name
+        ]
+    )
+    body = rooms.RoomUpdate(name="pantry")
+
+    result = await rooms.update_room("kitchen", body, session)
+
+    assert result.name == "pantry"
+    assert session.commits == 1
+    assert session.nested_begins == 1
+    statement, args, _ = session.execute_calls[2]
+    assert "UPDATE training_samples" in str(statement)
+    assert args[0] == {"new_name": "pantry", "old_name": "kitchen"}
+
+
+@pytest.mark.asyncio
+async def test_update_room_rename_survives_training_samples_permission_error() -> None:
+    session = FakeSession(
+        execute_results=[
+            FakeExecuteResult(scalar_value=_room("kitchen")),
+            FakeExecuteResult(),  # UPDATE csi_samples
+            ProgrammingError(
+                "UPDATE training_samples ...",
+                {},
+                Exception("permission denied for table training_samples"),
+            ),
+            FakeExecuteResult(scalar_value=_room("pantry")),
+        ]
+    )
+    body = rooms.RoomUpdate(name="pantry")
+
+    result = await rooms.update_room("kitchen", body, session)
+
+    assert result.name == "pantry"
+    assert session.commits == 1
+
+
+@pytest.mark.asyncio
+async def test_update_room_floor_only_change_skips_label_rewrites() -> None:
+    session = FakeSession(
+        execute_results=[
+            FakeExecuteResult(scalar_value=_room("kitchen", floor=0)),
+            FakeExecuteResult(scalar_value=_room("kitchen", floor=1)),
+        ]
+    )
+    body = rooms.RoomUpdate(floor=1)
+
+    result = await rooms.update_room("kitchen", body, session)
+
+    assert result.floor == 1
+    assert session.commits == 1
+    assert session.nested_begins == 0
+    assert len(session.execute_calls) == 2


### PR DESCRIPTION
Fixes #57 (P0 from the 2026-06 review, epic #54). **Stack position: 1/5** — this PR is the base of a stacked series; later PRs target this branch and will retarget to `main` as each one merges.

## What was wrong

`PATCH /api/rooms/{name}` updated `labels.room` (FK cascade) and `csi_samples.label`, but never `training_samples.label` — the denormalized column `GET /api/training-data` filters on and Nornir trains from. After a rename, the renamed room's historical training data was silently orphaned under the old name.

## The fix

- The rename now rewrites `training_samples.label` in the same transaction, under a savepoint so a real failure aborts the whole rename rather than splitting the tables between two names.
- Installs where `training_samples` is owned by a different role (#34/#37) skip the sync with a `training_samples.rename_skipped` warning, matching the labels router's existing degraded mode.
- New `freki/tests/test_rooms.py` covers the rename rewrite, the permission-denied carve-out, and the floor-only path (this router previously had zero tests).
- `docs/api-reference.md` and the router docstring now state the full propagation.

Note: this PR keeps the rename UPDATEs inline; PR 2 in the stack (#62) adds the lock/statement timeouts and background-task pattern so they can't hang on compressed chunks.

`pytest freki/tests` — 30 passed. Pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011P84UZViqZqR1dZpsD5CsC

---
_Generated by [Claude Code](https://claude.ai/code/session_011P84UZViqZqR1dZpsD5CsC)_