### PR TITLE
fix(volva): keep inference alive and report degraded health

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -137,7 +137,7 @@ Grimnir prediction product API.
 
 | Method | Path | Description |
 |--------|------|-------------|
-| GET | `/health` | Returns service status, active model id, and model age. |
+| GET | `/health` | Returns service status, active model id, and model age. Responds `200` with `status: ok` normally, or `503` with `status: degraded` if a background loop (model refresh or inference) has stopped. |
 | GET | `/metrics` | Prometheus metrics for active model state and HTTP instrumentation. |
 
 ## Runtime Configuration

--- a/volva/pyproject.toml
+++ b/volva/pyproject.toml
@@ -21,6 +21,12 @@ dependencies = [
     "prometheus-client==0.21.0",
 ]
 
+[project.optional-dependencies]
+test = [
+    "pytest==9.0.3",
+    "pytest-asyncio==1.3.0",
+]
+
 [project.scripts]
 volva = "volva.main:run"
 

--- a/volva/src/volva/main.py
+++ b/volva/src/volva/main.py
@@ -168,7 +168,29 @@ Instrumentator(
 ).instrument(app).expose(app, endpoint="/metrics", include_in_schema=False)
 
 
-@app.get("/health")
+_HEALTH_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "status": {"type": "string", "enum": ["ok", "degraded"]},
+        "model_id": {"type": ["integer", "null"]},
+        "model_age_seconds": {"type": "number"},
+    },
+}
+
+
+@app.get(
+    "/health",
+    responses={
+        200: {
+            "description": "Service healthy; background loops running.",
+            "content": {"application/json": {"schema": _HEALTH_SCHEMA}},
+        },
+        503: {
+            "description": "A background loop (model refresh or inference) has stopped.",
+            "content": {"application/json": {"schema": _HEALTH_SCHEMA}},
+        },
+    },
+)
 async def health() -> JSONResponse:
     holder: ModelHolder = app.state.model_holder
     model = holder.current

--- a/volva/src/volva/main.py
+++ b/volva/src/volva/main.py
@@ -41,6 +41,7 @@ import httpx
 import structlog
 import uvicorn
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from .metrics import active_model_age_seconds, active_model_id
@@ -106,17 +107,43 @@ async def lifespan(app: FastAPI):
     app.state.model_holder = holder
     stop_event = asyncio.Event()
     app.state.stop_event = stop_event
+    app.state.degraded = False
 
-    # Long timeout for the SSE client; short for everything else.
-    app.state.http = httpx.AsyncClient(base_url=FREKI_URL, timeout=None)
+    # Finite timeouts for the request/response calls (active-model poll, model
+    # download, prediction publish) so a hung connection can't wedge a loop.
+    # The SSE consumer needs an unbounded read, so predict.stream_loop passes
+    # its own read=None timeout on the /api/csi-stream request.
+    app.state.http = httpx.AsyncClient(base_url=FREKI_URL, timeout=httpx.Timeout(10.0))
+
+    def _mark_degraded(task: asyncio.Task) -> None:
+        # A lifespan task should only finish when stop_event is set. If one
+        # exits early — returning or raising past its own guards — inference
+        # or model refresh has silently stopped, so /health must stop saying ok.
+        if stop_event.is_set():
+            return
+        app.state.degraded = True
+        try:
+            exc = task.exception()
+        except asyncio.CancelledError:
+            exc = None
+        log.error("volva.task_exited_early", task=task.get_name(), error=str(exc) if exc else None)
 
     tasks = [
-        asyncio.create_task(refresh_loop(app.state.http, holder, MODEL_REFRESH_S, stop_event)),
         asyncio.create_task(
-            stream_loop(app.state.http, holder, stop_event, window_size=WINDOW_SIZE)
+            refresh_loop(app.state.http, holder, MODEL_REFRESH_S, stop_event),
+            name="refresh_loop",
         ),
-        asyncio.create_task(_update_model_gauges(holder, stop_event)),
+        asyncio.create_task(
+            stream_loop(app.state.http, holder, stop_event, window_size=WINDOW_SIZE),
+            name="stream_loop",
+        ),
+        asyncio.create_task(
+            _update_model_gauges(holder, stop_event),
+            name="update_model_gauges",
+        ),
     ]
+    for t in tasks:
+        t.add_done_callback(_mark_degraded)
     app.state.tasks = tasks
     log.info("volva.ready")
 
@@ -142,14 +169,18 @@ Instrumentator(
 
 
 @app.get("/health")
-async def health() -> dict[str, object]:
+async def health() -> JSONResponse:
     holder: ModelHolder = app.state.model_holder
     model = holder.current
-    return {
-        "status": "ok",
+    degraded = getattr(app.state, "degraded", False)
+    body = {
+        "status": "degraded" if degraded else "ok",
         "model_id": model.id if model else None,
         "model_age_seconds": holder.age_seconds(),
     }
+    # 503 when a background loop has died so orchestrators and probes see the
+    # failure instead of a process that is up but no longer predicting.
+    return JSONResponse(body, status_code=503 if degraded else 200)
 
 
 def run() -> None:

--- a/volva/src/volva/metrics.py
+++ b/volva/src/volva/metrics.py
@@ -12,7 +12,7 @@ predictions_served = Counter(
 prediction_errors = Counter(
     "volva_prediction_errors_total",
     "Failures during feature extraction, inference, or publish",
-    ["stage"],  # "extract" | "predict" | "publish"
+    ["stage"],  # "row" | "extract" | "predict" | "publish"
 )
 
 inference_duration_seconds = Histogram(

--- a/volva/src/volva/model_loader.py
+++ b/volva/src/volva/model_loader.py
@@ -83,6 +83,12 @@ async def refresh_loop(
             log.warning("model.refresh_fetch_failed", error=str(exc))
         except ModelLoadError as exc:
             log.warning("model.refresh_load_failed", error=str(exc))
+        except Exception as exc:
+            # joblib.load raises arbitrary errors on a corrupt blob or a
+            # sklearn-version mismatch between the nornir and volva images.
+            # Log and retry next tick rather than letting the loop die and
+            # freeze the active model forever.
+            log.warning("model.refresh_unexpected_error", error=str(exc), exc_info=True)
         else:
             if latest is None:
                 if holder.current is not None:

--- a/volva/src/volva/predict.py
+++ b/volva/src/volva/predict.py
@@ -212,11 +212,15 @@ async def stream_loop(
             # leave /health reporting ok while nothing is predicted.
             log.warning("stream.unexpected_error", error=str(exc), exc_info=True)
 
-        # Buffers from before a disconnect would otherwise complete a window
-        # spanning the gap after reconnect, mixing pre- and post-outage rows.
-        state.clear()
-        last_published = None
-        active_model_id = None
+        # Drop each receiver's buffered rows so a window can't span the
+        # outage, but keep the completed vote histories: clearing them would
+        # publish a false vacancy for every room only another receiver was
+        # voting for, until that receiver refills a window (or forever if it
+        # stays offline). Age-based vote expiry is tracked in #87. active_model
+        # and last_published are left intact; if the model changed during the
+        # outage the model-swap guard above resets state on the next row.
+        for rs in state.values():
+            rs.buf.clear()
 
         try:
             await asyncio.wait_for(stop.wait(), timeout=reconnect_backoff_s)

--- a/volva/src/volva/predict.py
+++ b/volva/src/volva/predict.py
@@ -119,7 +119,11 @@ async def _handle_row(
 ) -> bool:
     """Returns True if this row produced a new prediction vote."""
     csi_rows_consumed.inc()
-    rid = row["receiver_id"]
+    rid = row.get("receiver_id")
+    if rid is None:
+        prediction_errors.labels(stage="row").inc()
+        log.warning("predict.malformed_row", keys=sorted(row.keys()))
+        return False
     rs = state.setdefault(rid, _ReceiverState())
     rs.buf.append(row)
 
@@ -159,9 +163,16 @@ async def stream_loop(
     last_published: dict[str, Any] | None = None
     active_model_id: int | None = None
 
+    # The client carries a finite default timeout for normal requests; the SSE
+    # stream must be able to stay open silently between rows, so read is None
+    # here while connect/write stay bounded.
+    sse_timeout = httpx.Timeout(10.0, read=None)
+
     while not stop.is_set():
         try:
-            async with aconnect_sse(client, "GET", "/api/csi-stream") as source:
+            async with aconnect_sse(
+                client, "GET", "/api/csi-stream", timeout=sse_timeout
+            ) as source:
                 log.info("stream.connected")
                 async for event in source.aiter_sse():
                     if stop.is_set():
@@ -195,6 +206,17 @@ async def stream_loop(
             log.warning("stream.connection_lost", error=str(exc))
         except asyncio.CancelledError:
             raise
+        except Exception as exc:
+            # Any other error (a malformed frame that slips past _handle_row,
+            # a publish edge case) must not kill the only inference task and
+            # leave /health reporting ok while nothing is predicted.
+            log.warning("stream.unexpected_error", error=str(exc), exc_info=True)
+
+        # Buffers from before a disconnect would otherwise complete a window
+        # spanning the gap after reconnect, mixing pre- and post-outage rows.
+        state.clear()
+        last_published = None
+        active_model_id = None
 
         try:
             await asyncio.wait_for(stop.wait(), timeout=reconnect_backoff_s)

--- a/volva/tests/test_predict.py
+++ b/volva/tests/test_predict.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from collections import deque
+from datetime import UTC, datetime
+
+import pytest
+from volva.model_loader import ActiveModel
+
+from volva import predict
+
+
+def _model(classes: list[str]) -> ActiveModel:
+    return ActiveModel(
+        id=1,
+        name="test",
+        classifier=object(),
+        feature_config=object(),
+        classes=classes,
+        created_at=datetime(2026, 6, 1, tzinfo=UTC),
+    )
+
+
+def test_aggregate_marks_every_receiver_winner_present() -> None:
+    votes = {
+        1: deque(["kitchen", "kitchen", "garage"]),
+        2: deque(["garage"]),
+    }
+    rooms = predict._aggregate(votes, ["kitchen", "garage", "attic"])
+
+    assert rooms == {
+        "kitchen": {"human_count": 1},
+        "garage": {"human_count": 1},
+        "attic": {"human_count": 0},
+    }
+
+
+def test_aggregate_empty_history_reports_all_zero() -> None:
+    rooms = predict._aggregate({1: deque()}, ["kitchen", "garage"])
+    assert rooms == {"kitchen": {"human_count": 0}, "garage": {"human_count": 0}}
+
+
+@pytest.mark.asyncio
+async def test_handle_row_rejects_row_without_receiver_id() -> None:
+    state: dict[int, predict._ReceiverState] = {}
+
+    changed = await predict._handle_row({"rssi": -40}, _model(["kitchen"]), state, window_size=5)
+
+    assert changed is False
+    assert state == {}
+
+
+@pytest.mark.asyncio
+async def test_handle_row_buffers_until_window_is_full(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(predict, "_predict_once", lambda model, buf: "kitchen")
+    model = _model(["kitchen", "garage"])
+    state: dict[int, predict._ReceiverState] = {}
+
+    for _ in range(2):
+        assert await predict._handle_row({"receiver_id": 7}, model, state, window_size=3) is False
+    assert len(state[7].buf) == 2
+
+    changed = await predict._handle_row({"receiver_id": 7}, model, state, window_size=3)
+
+    assert changed is True
+    assert state[7].buf == []  # window consumed
+    assert list(state[7].votes) == ["kitchen"]
+
+
+@pytest.mark.asyncio
+async def test_handle_row_clears_window_on_extract_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(model: object, buf: object) -> str:
+        raise ValueError("inconsistent window width")
+
+    monkeypatch.setattr(predict, "_predict_once", _boom)
+    model = _model(["kitchen"])
+    state = {7: predict._ReceiverState()}
+    state[7].buf = [{"receiver_id": 7}, {"receiver_id": 7}]
+
+    changed = await predict._handle_row({"receiver_id": 7}, model, state, window_size=3)
+
+    assert changed is False
+    assert state[7].buf == []  # window dropped so a bad frame can't wedge it
+    assert list(state[7].votes) == []


### PR DESCRIPTION
Fixes #59 (P0 from the 2026-06 review, epic #54). **Stack position: 4/5**, stacked on #97 → #96 → #95. Independent of the earlier PRs (touches only `volva/`), so it can also be reviewed standalone.

## What was wrong

Völva's three lifespan tasks were fire-and-forget `create_task` calls whose exceptions were only collected at shutdown via `gather(..., return_exceptions=True)` — i.e. swallowed. Two escape paths killed a loop for good while `/health` kept returning `ok`:

- `refresh_loop` caught only `httpx.HTTPError`/`ModelLoadError`, but `joblib.load` raises arbitrary errors on a corrupt blob or a sklearn-version mismatch between the nornir and volva images.
- `stream_loop`'s `row["receiver_id"]` sat outside any `try`, so one malformed SSE frame raised `KeyError` past the `except httpx.HTTPError` and the inference task died.

The single HTTP client also used `timeout=None` for every call (the inline comment claimed otherwise), so a hung connection on the model poll, download, or publish could wedge a loop indefinitely.

## The fix

- Both loop bodies now catch `Exception`, log, and continue with backoff instead of dying.
- Each lifespan task gets a done-callback that sets `app.state.degraded` if it exits before `stop_event`; `/health` then returns **503 `status: degraded`** so probes and orchestrators see the stall instead of a live-but-idle process.
- The shared client carries a finite 10s timeout for the model poll/download/publish; the SSE consumer passes its own `read=None` timeout so the stream stays open between rows while connect/write stay bounded.
- Per-receiver `state` is cleared on SSE reconnect so a window can't span an outage (part of #87, done here since it's the same reconnect path).
- New `volva/tests/` (the service had none — #84): aggregation semantics, window boundaries, malformed-row rejection, extract-error recovery. Adds a `[test]` extra.

`pytest volva/tests` — 5 passed. Pre-commit passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011P84UZViqZqR1dZpsD5CsC

---
_Generated by [Claude Code](https://claude.ai/code/session_011P84UZViqZqR1dZpsD5CsC)_