### PR TITLE
fix(nornir,volva): run blocking fit/serialize/load off the event loop

### DIFF
--- a/nornir/pyproject.toml
+++ b/nornir/pyproject.toml
@@ -17,6 +17,12 @@ dependencies = [
     "joblib==1.4.2",
 ]
 
+[project.optional-dependencies]
+test = [
+    "pytest==9.0.3",
+    "pytest-asyncio==1.3.0",
+]
+
 [project.scripts]
 nornir = "nornir.main:run"
 

--- a/nornir/src/nornir/train.py
+++ b/nornir/src/nornir/train.py
@@ -18,6 +18,7 @@ Völva translates a predicted room into ``{room: {human_count: 1}}``.
 
 from __future__ import annotations
 
+import asyncio
 import io
 import time
 from collections.abc import AsyncIterator
@@ -194,12 +195,16 @@ async def run_job(
         classes=sorted(set(y.tolist())),
     )
 
-    clf, metrics = _fit_model(x, y, hyperparams)
+    # fit and serialize are CPU-bound and synchronous; run them off the event
+    # loop so the daemon's job/daemon heartbeats keep flowing. A fit that
+    # blocked the loop past ORPHAN_TIMEOUT_S would let Freki's reaper mark the
+    # job orphaned and requeue it mid-train (#60).
+    clf, metrics = await asyncio.to_thread(_fit_model, x, y, hyperparams)
     metrics["n_rows_fetched"] = row_count
     metrics["window_size"] = window_size
     metrics["feature_version"] = FEATURE_VERSION
 
-    model_bytes = _serialize(clf)
+    model_bytes = await asyncio.to_thread(_serialize, clf)
     log.info(
         "train.finished",
         job_id=job["id"],

--- a/nornir/tests/test_train.py
+++ b/nornir/tests/test_train.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import numpy as np
@@ -35,6 +36,20 @@ async def test_run_job_trains_and_serializes_via_offloaded_path(
 
     monkeypatch.setattr(train, "_collect_windows", _fake_collect)
 
+    # Record what run_job hands to asyncio.to_thread. This is the actual
+    # regression guard: reverting either offload to a direct synchronous call
+    # (which reintroduces the heartbeat starvation this PR fixes) drops the
+    # function from `submitted` and fails the assertion below, whereas the
+    # output assertions alone would still pass.
+    submitted: list[str] = []
+    real_to_thread = asyncio.to_thread
+
+    async def _spy_to_thread(func, /, *args, **kwargs):
+        submitted.append(getattr(func, "__name__", repr(func)))
+        return await real_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", _spy_to_thread)
+
     job = {
         "id": 1,
         "spec": {
@@ -54,3 +69,5 @@ async def test_run_job_trains_and_serializes_via_offloaded_path(
     assert metrics["n_rows_fetched"] == 200
     assert sorted(metrics["classes"]) == ["garage", "kitchen"]
     assert feature_config["version"] == FEATURE_VERSION
+    # Both CPU-bound calls must be offloaded, fit before serialize.
+    assert submitted == ["_fit_model", "_serialize"]

--- a/nornir/tests/test_train.py
+++ b/nornir/tests/test_train.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+from csi_models.features import FEATURE_VERSION
+
+from nornir import train
+
+
+class _FakeClient:
+    """Stand-in for FrekiClient; iter_training_data is never consumed here
+    because _collect_windows is stubbed to return a fixed dataset."""
+
+    def iter_training_data(self, **_kwargs: Any):
+        async def _empty():
+            if False:
+                yield {}
+
+        return _empty()
+
+
+@pytest.mark.asyncio
+async def test_run_job_trains_and_serializes_via_offloaded_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A tiny, linearly separable two-class set; enough per class for the
+    # stratified 80/20 split inside _fit_model.
+    x = np.array([[float(i), float(i)] for i in range(10)], dtype=np.float32)
+    y = np.array(["kitchen", "garage"] * 5)
+
+    async def _fake_collect(row_stream, *, window_size, feature_config):
+        return x, y, 200
+
+    monkeypatch.setattr(train, "_collect_windows", _fake_collect)
+
+    job = {
+        "id": 1,
+        "spec": {
+            "rooms": ["kitchen", "garage"],
+            "time_start": "2026-06-01T00:00:00Z",
+            "time_end": "2026-06-01T01:00:00Z",
+            "feature_config": {"version": FEATURE_VERSION},
+            "hyperparams": {"n_estimators": 5, "window_size": 50},
+        },
+    }
+
+    model_bytes, metrics, feature_config = await train.run_job(client=_FakeClient(), job=job)
+
+    assert isinstance(model_bytes, bytes) and model_bytes
+    assert metrics["window_size"] == 50
+    assert metrics["feature_version"] == FEATURE_VERSION
+    assert metrics["n_rows_fetched"] == 200
+    assert sorted(metrics["classes"]) == ["garage", "kitchen"]
+    assert feature_config["version"] == FEATURE_VERSION

--- a/volva/src/volva/model_loader.py
+++ b/volva/src/volva/model_loader.py
@@ -55,7 +55,9 @@ async def fetch_active(client: httpx.AsyncClient) -> ActiveModel | None:
 
     data_resp = await client.get(f"/api/models/{meta['id']}/data")
     data_resp.raise_for_status()
-    clf = joblib.load(io.BytesIO(data_resp.content))
+    # joblib.load is synchronous and can take a while on a large forest; run it
+    # off the event loop so the refresh poll doesn't stall inference (#60).
+    clf = await asyncio.to_thread(joblib.load, io.BytesIO(data_resp.content))
 
     if not hasattr(clf, "predict") or not hasattr(clf, "classes_"):
         raise ModelLoadError("loaded object is not a sklearn classifier")


### PR DESCRIPTION
Fixes #60 (P1 from the 2026-06 review, epic #54). **Stack position: 5/5**, stacked on #98 → #97 → #96 → #95.

## What was wrong

`clf.fit` and `joblib.dump(compress=3)` ran synchronously inside the async `run_job`, blocking the event loop for the entire fit. While blocked, Nornir's `_periodic_job_heartbeat` and `_daemon_heartbeat_loop` couldn't run — so any fit longer than Freki's `ORPHAN_TIMEOUT_S` (300s; the `rows_fetched` buckets go to 10M rows) let the reaper mark the job orphaned and requeue it mid-train. A second daemon then retrained the same job, and the original's `complete_job` failed on the nulled claim token. Völva's `joblib.load` blocked its refresh loop the same way on every model swap.

## The fix

Wrap the three synchronous, CPU-bound calls in `asyncio.to_thread` (`_fit_model` and `_serialize` in Nornir, `joblib.load` in Völva) so the loops keep servicing heartbeats and inference while they run.

- Adds `nornir/tests/` — the service's first test (part of #84): `run_job` still trains and serializes a correct model through the offloaded path, asserting the metrics/feature-config output. Adds a `[test]` extra.

`pytest nornir/tests volva/tests` — 6 passed. Pre-commit passes.

Note: this does not change the reaper timeout or the train/serve `window_size` skew — those remain in #61 and the reaper attempt-cap in #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011P84UZViqZqR1dZpsD5CsC

---
_Generated by [Claude Code](https://claude.ai/code/session_011P84UZViqZqR1dZpsD5CsC)_