### PR TITLE
ci: run the nornir and volva test suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e mimir[features] -e geri[test] -e freki[test]
+          python -m pip install -e mimir[features] -e geri[test] -e freki[test] -e nornir[test] -e volva[test]
 
       - name: Run pytest
-        run: pytest geri/tests freki/tests
+        run: pytest geri/tests freki/tests nornir/tests volva/tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,10 +152,10 @@ jobs:
       - name: Install test dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e mimir[features] -e geri[test] -e freki[test]
+          python -m pip install -e mimir[features] -e geri[test] -e freki[test] -e nornir[test] -e volva[test]
 
       - name: Run pytest
-        run: pytest geri/tests freki/tests
+        run: pytest geri/tests freki/tests nornir/tests volva/tests
 
   # ── Build and push container images ───────────────────────────────────────
   images:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,4 +43,6 @@ asyncio_mode = "auto"
 testpaths = [
     "geri/tests",
     "freki/tests",
+    "nornir/tests",
+    "volva/tests",
 ]


### PR DESCRIPTION
Refs #84. **Stack position: 6/6** (top), stacked on #99 → #98 → #97 → #96 → #95.

## Why

Codex flagged on both #98 and #99 that the new `volva/tests` and `nornir/tests` suites are never collected in CI: `ci.yml` and `release.yml` install and run only geri + freki tests, and the root `testpaths` omitted both. A regression that reintroduced the silent-task-death (#59) or blocking-fit (#60) behavior would pass every required check. This PR closes that gap once for both suites, since the fix is at the workflow level rather than in either service.

## Changes

- `.github/workflows/ci.yml` and `release.yml`: install `nornir[test]` and `volva[test]` and add `nornir/tests volva/tests` to the pytest invocation.
- root `pyproject.toml` `testpaths`: add both suites so a bare `pytest` matches CI.

Running the full configured `testpaths` locally: **50 passed** across geri, freki, nornir, and volva.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011P84UZViqZqR1dZpsD5CsC

---
_Generated by [Claude Code](https://claude.ai/code/session_011P84UZViqZqR1dZpsD5CsC)_